### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ after_success: npm run coveralls
 language: node_js
 
 node_js:
-  - "4.0"
   - "4"
   - "5"
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const Thurston = require('thurston');
 
 const options = { whitelist: ['image/png'] };
 
-Fs.createWriteStream('file.png').end(new Buffer('89504e47', 'hex'));
+Fs.createWriteStream('file.png').end(Buffer.from('89504e47', 'hex'));
 const png = Fs.createReadStream('file.png');
 
 Thurston.validate({ file: png }, options, (err, value) => {
@@ -77,7 +77,7 @@ const Thurston = require('thurston');
 
 const options = { whitelist: ['image/png'] };
 
-Fs.createWriteStream('file.gif').end(new Buffer('47494638', 'hex'));
+Fs.createWriteStream('file.gif').end(Buffer.from('47494638', 'hex'));
 const gif = Fs.createReadStream('file.gif');
 
 Thurston.validate({ file: gif }, options, (err, value) => {

--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
   },
   "homepage": "https://github.com/ruiquelhas/thurston#readme",
   "devDependencies": {
-    "code": "3.x.x",
+    "code": "4.x.x",
     "coveralls": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
-    "multi-part": "1.x.x"
+    "hapi": "15.x.x",
+    "lab": "11.x.x",
+    "multi-part": "2.x.x"
   },
   "dependencies": {
     "houdin": "2.x.x",
     "items": "2.x.x"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -58,7 +58,7 @@ lab.experiment('Thurston', () => {
         form.append('file', Fs.createReadStream(invalid));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(400);
             Code.expect(response.result).to.include(['message', 'validation']);
@@ -81,7 +81,7 @@ lab.experiment('Thurston', () => {
         form.append('file2', Fs.createReadStream(png));
         form.append('foo', 'bar');
 
-        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.get(), url: '/' }, (response) => {
+        server.inject({ headers: form.getHeaders(), method: 'POST', payload: form.stream(), url: '/' }, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
             done();

--- a/test/index.js
+++ b/test/index.js
@@ -52,7 +52,7 @@ lab.experiment('Thurston', () => {
 
         const invalid = Path.join(Os.tmpdir(), 'invalid');
 
-        Fs.createWriteStream(invalid).end(new Buffer('ffffffff', 'hex'));
+        Fs.createWriteStream(invalid).end(Buffer.from('ffffffff', 'hex'));
 
         const form = new Form();
         form.append('file', Fs.createReadStream(invalid));
@@ -74,7 +74,7 @@ lab.experiment('Thurston', () => {
 
         const png = Path.join(Os.tmpdir(), 'foo.png');
 
-        Fs.createWriteStream(png).end(new Buffer('89504e47', 'hex'));
+        Fs.createWriteStream(png).end(Buffer.from('89504e47', 'hex'));
 
         const form = new Form();
         form.append('file1', Fs.createReadStream(png));


### PR DESCRIPTION
Update 3rd-party modules and supported node engine. Switch to the new `Buffer` API available since `v4.5.0`.