### PR TITLE
Update `hapi` to skip vulnerable versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "code": "4.x.x",
     "coveralls": "2.x.x",
-    "hapi": "16.x.x",
+    "hapi": "16.2.x",
     "lab": "13.x.x",
     "multi-part": "2.x.x"
   },


### PR DESCRIPTION
Make sure badges don't scare people.

https://nodesecurity.io/advisories/hapi_denial-of-service-via-malformed-accept-encoding-header